### PR TITLE
Use utf8mb4 as MySQL charset

### DIFF
--- a/config/config_default-test.php
+++ b/config/config_default-test.php
@@ -48,7 +48,7 @@ $connections = [
         'settings' => [
             'charset' => 'utf8',
             'queries' => [
-                'utf8' => 'SET NAMES utf8 COLLATE utf8_unicode_ci, COLLATION_CONNECTION = utf8_unicode_ci, COLLATION_DATABASE = utf8_unicode_ci, COLLATION_SERVER = utf8_unicode_ci',
+                'utf8' => 'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci, COLLATION_CONNECTION = utf8mb4_unicode_ci, COLLATION_DATABASE = utf8mb4_unicode_ci, COLLATION_SERVER = utf8mb4_unicode_ci',
             ],
         ],
     ],


### PR DESCRIPTION
MySQL’s utf8 only allows you to store ~6% of all possible unicode code points. Real utf-8 can contain way more than MySQL allows with its utf8. This means, with the old setup, it is not possible to store most of utf8 characters you can enter in your browser. If you would try to store such characters the query would fail.

I'd also propose to reset `sql_mode` which has since MySQL 5.7.5 `only_full_group_by` active that breaks some queries in Propel as only_full_group_by forbids you to have columns in the SELECT statement without aggregation function that are not in the GROUP BY.

```php
                'mode': "set sql_mode = ''",
```