### PR TITLE
Fixed DropPostgreSqlDatabase::getPostgresVersion

### DIFF
--- a/src/Spryker/Zed/Propel/Business/Model/PropelDatabase/Adapter/PostgreSql/DropPostgreSqlDatabase.php
+++ b/src/Spryker/Zed/Propel/Business/Model/PropelDatabase/Adapter/PostgreSql/DropPostgreSqlDatabase.php
@@ -70,7 +70,7 @@ class DropPostgreSqlDatabase implements DropDatabaseInterface
      */
     protected function getPostgresVersion()
     {
-        $process = $this->getProcess('psql --version | awk \'{print $3}\' | cut -f1,2 -d\'.\'');
+        $process = $this->getProcess('psql --version | awk \'{print $3}\' | cut -f1,1 -d\'.\'');
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
This method returns the full version number. For example 10.5
But we need only the major version 10.  The database cannot be dropped, if you have 10.5.