### PR TITLE
CC-26467: Backport for Propel filter to criteria mapping

### DIFF
--- a/tests/SprykerTest/Zed/Propel/Business/PropelFilterCriteriaTest.php
+++ b/tests/SprykerTest/Zed/Propel/Business/PropelFilterCriteriaTest.php
@@ -25,38 +25,114 @@ use Spryker\Zed\Propel\PropelFilterCriteria;
 class PropelFilterCriteriaTest extends Unit
 {
     /**
+     * @dataProvider paginationDataProvider
+     *
+     * @param int|null $limit
+     * @param int|null $offset
+     * @param int|null $expectedLimit
+     * @param int|null $expectedOffset
+     *
      * @return void
      */
-    public function testToCriteriaShouldReturnEmptyCriteriaWhenNothingWasSet(): void
-    {
-        $filterTransfer = new FilterTransfer();
+    public function testToCriteriaShouldReturnCriteriaWithPagination(
+        ?int $limit,
+        ?int $offset,
+        ?int $expectedLimit,
+        ?int $expectedOffset
+    ): void {
+        // Arrange
+        $filterTransfer = (new FilterTransfer())
+            ->setLimit($limit)
+            ->setOffset($offset);
+        $propelFilterCriteria = new PropelFilterCriteria($filterTransfer);
 
-        $filterCriteria = new PropelFilterCriteria($filterTransfer);
-        $propelCriteria = $filterCriteria->toCriteria();
+        // Act
+        $criteria = $propelFilterCriteria->toCriteria();
 
-        $this->assertInstanceOf(Criteria::class, $propelCriteria);
-        $this->assertSame(-1, $propelCriteria->getLimit());
-        $this->assertSame(0, $propelCriteria->getOffset());
-        $this->assertSame([], $propelCriteria->getOrderByColumns());
+        // Assert
+        $this->assertSame($expectedLimit, $criteria->getLimit());
+        $this->assertSame($expectedOffset, $criteria->getOffset());
     }
 
     /**
+     * @dataProvider sortingDataProvider
+     * @dataProvider invalidSortingDataProvider
+     *
+     * @param string|null $orderByColumnName
+     * @param string|null $orderDirection
+     * @param string|null $expectedOrderByColumnName
+     * @param string|null $expectedOrderDirection
+     *
      * @return void
      */
-    public function testToCriteriaShouldReturnCriteriaWithParameters(): void
+    public function testToCriteriaShouldReturnCriteriaWithSorting(
+        ?string $orderByColumnName,
+        ?string $orderDirection,
+        ?string $expectedOrderByColumnName,
+        ?string $expectedOrderDirection
+    ): void {
+        // Arrange
+        $filterTransfer = (new FilterTransfer())
+            ->setOrderBy($orderByColumnName)
+            ->setOrderDirection($orderDirection);
+        $propelFilterCriteria = new PropelFilterCriteria($filterTransfer);
+        $expectedOrderbyColumns = [];
+        if ($expectedOrderByColumnName !== null && $expectedOrderDirection !== null) {
+            $expectedOrderbyColumns = [sprintf('%s %s', $expectedOrderByColumnName, $expectedOrderDirection)];
+        }
+
+        // Act
+        $criteria = $propelFilterCriteria->toCriteria();
+
+        // Assert
+        $this->assertSame($expectedOrderbyColumns, $criteria->getOrderByColumns());
+    }
+
+    /**
+     * @return array<string, array<array-key, int|null>>
+     */
+    protected function paginationDataProvider(): array
     {
-        $filterTransfer = new FilterTransfer();
-        $filterTransfer->setLimit(10);
-        $filterTransfer->setOffset(0);
-        $filterTransfer->setOrderDirection('DESC');
-        $filterTransfer->setOrderBy('foobar');
+        return [
+            'limit and offset are null' => [null, null, -1, 0],
+            'limit and offset are set' => [5, 10, 5, 10],
+            'limit is set, offset is null' => [10, null, 10, 0],
+            'offset is set, limit is null' => [null, 20, -1, 20],
+        ];
+    }
 
-        $filterCriteria = new PropelFilterCriteria($filterTransfer);
-        $propelCriteria = $filterCriteria->toCriteria();
+    /**
+     * @return array<string, array<array-key, string|null>>
+     */
+    protected function sortingDataProvider(): array
+    {
+        return [
+            'empty column name and direction asc' => [null, Criteria::ASC, null, Criteria::ASC],
+            'column name and empty direction' => ['created_at', null, 'created_at', null],
+            'column name with underscore and direction asc' => ['created_at', Criteria::ASC, 'created_at', Criteria::ASC],
+            'column name combined with table name and direction asc' => ['spy_product.created_at', Criteria::ASC, 'spy_product.created_at', Criteria::ASC],
+            'column name and sort direction asc' => ['created_at', Criteria::ASC, 'created_at', Criteria::ASC],
+            'column name and sort direction desc' => ['created_at', Criteria::DESC, 'created_at', Criteria::DESC],
+        ];
+    }
 
-        $this->assertInstanceOf(Criteria::class, $propelCriteria);
-        $this->assertSame(10, $propelCriteria->getLimit());
-        $this->assertSame(0, $propelCriteria->getOffset());
-        $this->assertEquals(['foobar DESC'], $propelCriteria->getOrderByColumns());
+    /**
+     * @return array<string, array<array-key, string|null>>
+     */
+    protected function invalidSortingDataProvider(): array
+    {
+        return [
+            'invalid column name with SQL injection' => ['created_at; SELECT * FROM users;', Criteria::ASC, null, Criteria::ASC],
+            'invalid column name with semicolon' => ['created_at;', Criteria::ASC, null, Criteria::ASC],
+            'invalid column name with spaces' => ['created at', Criteria::ASC, null, Criteria::ASC],
+            'invalid column name with special characters' => ['created_at#', Criteria::ASC, null, Criteria::ASC],
+            'invalid column name with brackets' => ['my_column()', Criteria::ASC, null, Criteria::ASC],
+            'invalid column name with quotes' => ["my_column'", Criteria::ASC, null, Criteria::ASC],
+            'invalid column name with backticks' => ['`my_column`', Criteria::ASC, null, Criteria::ASC],
+            'invalid column name with leading/trailing spaces' => [' column ', Criteria::ASC, null, Criteria::ASC],
+            'invalid column name with non-word characters' => ['col_name$', Criteria::ASC, null, Criteria::ASC],
+            'invalid column name with non-alphanumeric characters' => ['col:name', Criteria::ASC, null, Criteria::ASC],
+            'invalid column name with non-ASCII characters' => ['col_名', Criteria::ASC, null, Criteria::ASC],
+        ];
     }
 }

--- a/tests/SprykerTest/Zed/Propel/Business/PropelFilterCriteriaTest.php
+++ b/tests/SprykerTest/Zed/Propel/Business/PropelFilterCriteriaTest.php
@@ -25,114 +25,38 @@ use Spryker\Zed\Propel\PropelFilterCriteria;
 class PropelFilterCriteriaTest extends Unit
 {
     /**
-     * @dataProvider paginationDataProvider
-     *
-     * @param int|null $limit
-     * @param int|null $offset
-     * @param int|null $expectedLimit
-     * @param int|null $expectedOffset
-     *
      * @return void
      */
-    public function testToCriteriaShouldReturnCriteriaWithPagination(
-        ?int $limit,
-        ?int $offset,
-        ?int $expectedLimit,
-        ?int $expectedOffset
-    ): void {
-        // Arrange
-        $filterTransfer = (new FilterTransfer())
-            ->setLimit($limit)
-            ->setOffset($offset);
-        $propelFilterCriteria = new PropelFilterCriteria($filterTransfer);
+    public function testToCriteriaShouldReturnEmptyCriteriaWhenNothingWasSet(): void
+    {
+        $filterTransfer = new FilterTransfer();
 
-        // Act
-        $criteria = $propelFilterCriteria->toCriteria();
+        $filterCriteria = new PropelFilterCriteria($filterTransfer);
+        $propelCriteria = $filterCriteria->toCriteria();
 
-        // Assert
-        $this->assertSame($expectedLimit, $criteria->getLimit());
-        $this->assertSame($expectedOffset, $criteria->getOffset());
+        $this->assertInstanceOf(Criteria::class, $propelCriteria);
+        $this->assertSame(-1, $propelCriteria->getLimit());
+        $this->assertSame(0, $propelCriteria->getOffset());
+        $this->assertSame([], $propelCriteria->getOrderByColumns());
     }
 
     /**
-     * @dataProvider sortingDataProvider
-     * @dataProvider invalidSortingDataProvider
-     *
-     * @param string|null $orderByColumnName
-     * @param string|null $orderDirection
-     * @param string|null $expectedOrderByColumnName
-     * @param string|null $expectedOrderDirection
-     *
      * @return void
      */
-    public function testToCriteriaShouldReturnCriteriaWithSorting(
-        ?string $orderByColumnName,
-        ?string $orderDirection,
-        ?string $expectedOrderByColumnName,
-        ?string $expectedOrderDirection
-    ): void {
-        // Arrange
-        $filterTransfer = (new FilterTransfer())
-            ->setOrderBy($orderByColumnName)
-            ->setOrderDirection($orderDirection);
-        $propelFilterCriteria = new PropelFilterCriteria($filterTransfer);
-        $expectedOrderbyColumns = [];
-        if ($expectedOrderByColumnName !== null && $expectedOrderDirection !== null) {
-            $expectedOrderbyColumns = [sprintf('%s %s', $expectedOrderByColumnName, $expectedOrderDirection)];
-        }
-
-        // Act
-        $criteria = $propelFilterCriteria->toCriteria();
-
-        // Assert
-        $this->assertSame($expectedOrderbyColumns, $criteria->getOrderByColumns());
-    }
-
-    /**
-     * @return array<string, array<array-key, int|null>>
-     */
-    protected function paginationDataProvider(): array
+    public function testToCriteriaShouldReturnCriteriaWithParameters(): void
     {
-        return [
-            'limit and offset are null' => [null, null, -1, 0],
-            'limit and offset are set' => [5, 10, 5, 10],
-            'limit is set, offset is null' => [10, null, 10, 0],
-            'offset is set, limit is null' => [null, 20, -1, 20],
-        ];
-    }
+        $filterTransfer = new FilterTransfer();
+        $filterTransfer->setLimit(10);
+        $filterTransfer->setOffset(0);
+        $filterTransfer->setOrderDirection('DESC');
+        $filterTransfer->setOrderBy('foobar');
 
-    /**
-     * @return array<string, array<array-key, string|null>>
-     */
-    protected function sortingDataProvider(): array
-    {
-        return [
-            'empty column name and direction asc' => [null, Criteria::ASC, null, Criteria::ASC],
-            'column name and empty direction' => ['created_at', null, 'created_at', null],
-            'column name with underscore and direction asc' => ['created_at', Criteria::ASC, 'created_at', Criteria::ASC],
-            'column name combined with table name and direction asc' => ['spy_product.created_at', Criteria::ASC, 'spy_product.created_at', Criteria::ASC],
-            'column name and sort direction asc' => ['created_at', Criteria::ASC, 'created_at', Criteria::ASC],
-            'column name and sort direction desc' => ['created_at', Criteria::DESC, 'created_at', Criteria::DESC],
-        ];
-    }
+        $filterCriteria = new PropelFilterCriteria($filterTransfer);
+        $propelCriteria = $filterCriteria->toCriteria();
 
-    /**
-     * @return array<string, array<array-key, string|null>>
-     */
-    protected function invalidSortingDataProvider(): array
-    {
-        return [
-            'invalid column name with SQL injection' => ['created_at; SELECT * FROM users;', Criteria::ASC, null, Criteria::ASC],
-            'invalid column name with semicolon' => ['created_at;', Criteria::ASC, null, Criteria::ASC],
-            'invalid column name with spaces' => ['created at', Criteria::ASC, null, Criteria::ASC],
-            'invalid column name with special characters' => ['created_at#', Criteria::ASC, null, Criteria::ASC],
-            'invalid column name with brackets' => ['my_column()', Criteria::ASC, null, Criteria::ASC],
-            'invalid column name with quotes' => ["my_column'", Criteria::ASC, null, Criteria::ASC],
-            'invalid column name with backticks' => ['`my_column`', Criteria::ASC, null, Criteria::ASC],
-            'invalid column name with leading/trailing spaces' => [' column ', Criteria::ASC, null, Criteria::ASC],
-            'invalid column name with non-word characters' => ['col_name$', Criteria::ASC, null, Criteria::ASC],
-            'invalid column name with non-alphanumeric characters' => ['col:name', Criteria::ASC, null, Criteria::ASC],
-            'invalid column name with non-ASCII characters' => ['col_名', Criteria::ASC, null, Criteria::ASC],
-        ];
+        $this->assertInstanceOf(Criteria::class, $propelCriteria);
+        $this->assertSame(10, $propelCriteria->getLimit());
+        $this->assertSame(0, $propelCriteria->getOffset());
+        $this->assertEquals(['foobar DESC'], $propelCriteria->getOrderByColumns());
     }
 }


### PR DESCRIPTION
Branch: backport/3.34.3
Ticket: https://spryker.atlassian.net/browse/CC-26467
Version: 3.34.3
- Strategy: minor

#### Release Table

   Module                | Release Type         | Constraint Updates         
   :--------------------- | :------------------------ | :---------------------  |
   Propel  | patch                 |                        |

-----------------------------------------

#### Module Propel

##### Change log

Adjustments

- Adjusted `PropelFilterCriteria::toCriteria()` to properly map provided values from `FilterTransfer` to `Criteria`.
